### PR TITLE
Cache gems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .idea/
+/bundle

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,16 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     apt-get update && \
     apt-get install -y nodejs
 
-ENV BUNDLE_PATH /bundle
-
 ADD supervisor/supervisord.conf /etc/supervisord.conf
 COPY docker-entrypoint.sh /usr/local/bin/
+
+ENV BUNDLE_PATH /bundle
+
+COPY app/Gemfile .
+COPY app/Gemfile.lock .
+
+ARG bundle_on_build
+RUN if [ "$bundle_on_build" != "false" ]; then bundle install; fi
 
 COPY ./app /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,7 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     apt-get update && \
     apt-get install -y nodejs
 
-RUN gem install bundler
-
-COPY app/Gemfile .
-COPY app/Gemfile.lock .
-
-RUN bundle install
+ENV BUNDLE_PATH /bundle
 
 ADD supervisor/supervisord.conf /etc/supervisord.conf
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ Especially useful to run on Heroku in scope of single dyno. Such approach will r
 
 Including:
 1. Configured for default Heroku Postgres database;
-2. TODO: cache gems for local env
-3. Entrypoint script with automatic migration run
+2. Caching gems in case of running with compose
+3. Entrypoint script with automatic migration run and DB creation
 4. Configured supervisord
-5. docker-compose.yml for running localy
+4. Adapted to run on Heroku
+5. Included docker-compose.yml for running with docker in self hosted environment
 6. Installed DelayedJob
+6. TODO: Switch to Alpine distribution
 7. TODO: handle a case when running first time. Install Rails automatically then
 6. TODO: consider one click deployments to Heroku and DG
 7. TODO: allow to manage crontab

--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ Including:
 2. Caching gems in case of running with compose
 3. Entrypoint script with automatic migration run and DB creation
 4. Configured supervisord
-4. Adapted to run on Heroku
-5. Included docker-compose.yml for running with docker in self hosted environment
-6. Installed DelayedJob
-6. TODO: Switch to Alpine distribution
-7. TODO: handle a case when running first time. Install Rails automatically then
-6. TODO: consider one click deployments to Heroku and DG
-7. TODO: allow to manage crontab
-9. TODO: allow to specify the url to the repository where to clone from the existing app
-10. TODO: extract the customizations into a separate gem
+5. Adapted to run on Heroku in Docker deployment mode
+6. Included docker-compose.yml for running with Compose in self-hosted environment
+7. Installed and configured DelayedJob
+8. TODO: switch to Alpine distribution
+9. TODO: handle a case when running first time. Install Rails automatically then
+10. TODO: consider one click deployments to Heroku and DG
+11. TODO: allow to manage crontab
+12. TODO: allow to specify the url to the repository where to clone from the existing app
+13. TODO: extract the customizations into a separate gem
 
 Follow instructions gere to configure your Heroku app for Docker deployment:
 https://devcenter.heroku.com/articles/build-docker-images-heroku-yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - DATABASE_USERNAME=postgres
     volumes:
       - ./app:/app
+      - ./bundle:/bundle
 
   db:
     image: postgres:10.3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     tty: true
     build:
       context: .
+      args:
+        bundle_on_build: "false"
     ports:
       - '3000:3000'
     depends_on:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 set -e
 
+bundle check || bundle install
+
+chmod -R a+rwX $BUNDLE_PATH
+
 # Ensure local DB is created if external DB is not provided
 if [ -z "$DATABASE_URL" ]; then
-    rails db:create
+    bundle exec rails db:create
 fi
 
-rails db:migrate
+bundle exec rails db:migrate
 
 exec "$@"


### PR DESCRIPTION
Allow to cache gems in case of compose install.
Saves a lot of time because installs gems once.

Not relevant to Heroku Docker install because of the specifics.